### PR TITLE
Use rtree for candidate cells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 
 *.nc
+*.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
  "ndarray",
  "netcdf",
  "proj",
+ "rstar",
  "wkt",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ geo-types="0.7.13"
 geo-booleanop = "0.3.2"
 wkt = { version = "0.9.0", features = ["geo-types"] }
 clap = { version = "4.2.7", features = ["derive"] }
+rstar = "0.12.0"

--- a/environment.yml
+++ b/environment.yml
@@ -92,4 +92,3 @@ dependencies:
   - xz=5.2.6=h166bdaf_0
   - zlib=1.3.1=h4ab18f5_1
   - zstd=1.5.6=ha6fb4c9_0
-prefix: /home/david/miniconda3/envs/rust_proj_env

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -220,8 +220,9 @@ pub fn process_shape_intersections(
     let area_error_threshold = 0.05;
 
     // Build the R-tree from grid cells
-    let rtree = build_grid_rtree(&grid_cell_geom);
+    let rtree = build_grid_rtree(grid_cell_geom);
 
+    // Iterate over the basins and calculate the intersection with grid cells
     for (index, (basin_id, shape_geometry)) in shapes.into_iter().enumerate() {
         let shape_area = match shape_geometry {
             Geometry::Polygon(ref poly) => poly.unsigned_area(),

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -24,7 +24,8 @@ use rstar::AABB;
 
 use crate::utils::RvnGridWeights;
 use crate::io::read_lat_lon;
-use crate::cli::Cli;use crate::rtree::build_grid_rtree;
+use crate::cli::Cli;
+use crate::rtree::build_grid_rtree;
 
 
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -28,7 +28,7 @@ use crate::cli::Cli;
 use crate::rtree::build_grid_rtree;
 
 
-
+// Create a meshgrid from 1D arrays of latitude and longitude
 pub fn meshgrid(lat: &Array<f32, ndarray::Ix1>, lon: &Array<f32, ndarray::Ix1>) -> (Array<f32, ndarray::Ix2>, Array<f32, ndarray::Ix2>) {
     // Create 2D longitude by repeating lon along the rows
     let lon_2d = Array::from_shape_fn((lat.len(), lon.len()), |(_, j)| lon[j]);
@@ -100,6 +100,7 @@ pub fn create_gridcells_from_centers(lat: &Array2<f32>, lon: &Array2<f32>) -> (A
     (lath, lonh)
 }
 
+// Convert a list of coordinates to a Polygon
 pub fn shape_to_geometry(
     shape_coord: &[[f64; 2]],
     proj: &Proj,

--- a/src/io.rs
+++ b/src/io.rs
@@ -209,8 +209,13 @@ pub fn write_netcdf_output(file_path: &Path, netcdf_data: &Vec<(f64, usize, usiz
 
 /// Write intersection data to a .txt file
 pub fn write_txt_output(output_path: &Path, rvn_data: &mut RvnGridWeights) -> Result<(), Box<dyn Error>> {
-    // rvn_data.txt_data.sort_by_key(|k| &k.0);
-    rvn_data.txt_data.sort_by(|a, b| a.0.cmp(&b.0));
+    // Sort txt_data by the integer value of the first element (converted from String)
+    rvn_data.txt_data.sort_by(|a, b| {
+        // Parse the first element of each tuple to i32
+        let a_id: i32 = a.0.parse().expect("Failed to parse basin_id to i32");
+        let b_id: i32 = b.0.parse().expect("Failed to parse basin_id to i32");
+        a_id.cmp(&b_id)
+    });
     let output_file = File::create(output_path)?;
     let mut writer = BufWriter::new(output_file);
     writeln!(writer, ":GridWeights")?;

--- a/src/io.rs
+++ b/src/io.rs
@@ -169,10 +169,9 @@ pub fn read_shapefile(
             OGRFieldType::OFTString => {
                 field_value.into_string().ok_or("Failed to get string value")?
             },
-            OGRFieldType::OFTInteger => {
+            _ => {
                 field_value.into_int().ok_or("Failed to get integer value")?.to_string()
             },
-            _ => return Err("Invalid basin ID field".into()),
         };
         geometries.insert(basin_id, geo_geometry);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod io;
 mod geometry;
 mod utils;
 mod cli;
+mod rtree;
 
 use std::{
     error::Error,

--- a/src/rtree.rs
+++ b/src/rtree.rs
@@ -1,0 +1,44 @@
+use geo::prelude::*;
+use geo_types::Polygon;
+use rstar::{RTree, RTreeObject, AABB};
+
+#[derive(Debug)]
+pub struct GridCell {
+    pub ilat: usize,
+    pub ilon: usize,
+    pub polygon: Polygon<f64>,
+}
+
+impl RTreeObject for GridCell {
+    type Envelope = AABB<[f64; 2]>;
+
+    fn envelope(&self) -> Self::Envelope {
+        let bbox = self.polygon.bounding_rect().expect("Grid cell must have a bounding rectangle");
+        AABB::from_corners([bbox.min().x, bbox.min().y], [bbox.max().x, bbox.max().y])
+    }
+}
+
+// Implement PartialEq and Eq if needed
+impl PartialEq for GridCell {
+    fn eq(&self, other: &Self) -> bool {
+        self.ilat == other.ilat && self.ilon == other.ilon
+    }
+}
+
+impl Eq for GridCell {}
+
+pub fn build_grid_rtree(grid_cell_geom: &Vec<Vec<Polygon<f64>>>) -> RTree<GridCell> {
+    let mut grid_cells = Vec::new();
+
+    for (ilat, row) in grid_cell_geom.iter().enumerate() {
+        for (ilon, polygon) in row.iter().enumerate() {
+            grid_cells.push(GridCell {
+                ilat,
+                ilon,
+                polygon: polygon.clone(),
+            });
+        }
+    }
+
+    RTree::bulk_load(grid_cells)
+}

--- a/src/rtree.rs
+++ b/src/rtree.rs
@@ -27,15 +27,15 @@ impl PartialEq for GridCell {
 
 impl Eq for GridCell {}
 
-pub fn build_grid_rtree(grid_cell_geom: &Vec<Vec<Polygon<f64>>>) -> RTree<GridCell> {
+pub fn build_grid_rtree(grid_cell_geom: Vec<Vec<Polygon<f64>>>) -> RTree<GridCell> {
     let mut grid_cells = Vec::new();
 
-    for (ilat, row) in grid_cell_geom.iter().enumerate() {
-        for (ilon, polygon) in row.iter().enumerate() {
+    for (ilat, row) in grid_cell_geom.into_iter().enumerate() {
+        for (ilon, polygon) in row.into_iter().enumerate() {
             grid_cells.push(GridCell {
                 ilat,
                 ilon,
-                polygon: polygon.clone(),
+                polygon: polygon,
             });
         }
     }


### PR DESCRIPTION
Instead of iterating over the entire grid, we use rtree to find the candidate cells